### PR TITLE
Added include fstream to make it compile

### DIFF
--- a/cumcubes/src/cumcubes.cpp
+++ b/cumcubes/src/cumcubes.cpp
@@ -1,4 +1,5 @@
 // Copyright 2021 Zhihao Liang
+#include <fstream>
 #include <cstdint>
 #include <iostream>
 #include <pybind11/functional.h>


### PR DESCRIPTION
I'm unable to build the project on linux. I have pytorch installed but the build fails with error message:
```
/home/artop/CuMCubes/cumcubes/src/cumcubes.cpp:92:28: error: variable ‘std::ofstream ply_file’ has initializer but incomplete type
92 |     std::ofstream ply_file(filename, std::ios::out | std::ios::binary);
```

It seems that adding this include will make the build work again.
